### PR TITLE
Fixed Unicode issue by encoding $transcript to UTF-8

### DIFF
--- a/speech-recog.agi
+++ b/speech-recog.agi
@@ -61,6 +61,8 @@ use File::Copy qw(move);
 use File::Temp qw(tempfile);
 use LWP::UserAgent;
 use JSON;
+use Encode qw(encode);
+use utf8;
 $| = 1;
 
 # ----------------------------- #
@@ -270,7 +272,7 @@ if (!$uaresponse->is_success) {
 foreach (split(/\n/,$uaresponse->content)) {
 	my $jdata = decode_json($_);
 	for ( @{$jdata->{result}[0]->{alternative}} ) {
-		$response{utterance}  = $_->{transcript};
+		$response{utterance}  = encode('utf8', $_->{transcript});
 		$response{confidence} = $_->{confidence};
 	}
 }


### PR DESCRIPTION
This is one-line fix that encodes `$transcript` to UTF-8 so that non-ASCII characters are not interperted as garbage. Tested with Asterisk 1.8.22.0. With this fix, I can successfully give `${utterance}` to `googletts.agi` without any encoding issues.
