### PR TITLE
Update the cloud API version to GA

### DIFF
--- a/cli/speech-recog-cli-tiny.pl
+++ b/cli/speech-recog-cli-tiny.pl
@@ -28,7 +28,7 @@ use MIME::Base64;
 my %options;
 my $flac;
 my $key;
-my $url        = "https://speech.googleapis.com/v1beta1/speech";
+my $url        = "https://speech.googleapis.com/v1/speech";
 my $samplerate = 16000;
 my $language   = "en-US";
 my $output     = "detailed";
@@ -44,10 +44,10 @@ parse_options();
 
 my %config = (
 	"encoding"         => "FLAC",
-	"sample_rate"      => $samplerate,
-	"language_code"    => $language,
-	"profanity_filter" => $pro_filter,
-	"max_alternatives" => $results,
+	"sampleRateHertz"  => $samplerate,
+	"languageCode"     => $language,
+	"profanityFilter"  => $pro_filter,
+	"maxAlternatives"  => $results,
 );
 
 my $http = HTTP::Tiny->new(
@@ -88,7 +88,7 @@ foreach my $file (@ARGV) {
 
 	my %headers =('Content-Type' => "application/json");
 	my %options = ('headers' => \%headers, 'content' => encode_json(\%json));
-	my $response = $http->request('POST', "$url:syncrecognize?key=$key", \%options);
+	my $response = $http->request('POST', "$url:recognize?key=$key", \%options);
 	if (!$response->{'success'}) {
 		say_msg("Failed to get data for file: $file");
 		++$error;

--- a/cli/speech-recog-cli.pl
+++ b/cli/speech-recog-cli.pl
@@ -29,7 +29,7 @@ use MIME::Base64;
 my %options;
 my $flac;
 my $key;
-my $url        = "https://speech.googleapis.com/v1beta1/speech";
+my $url        = "https://speech.googleapis.com/v1/speech";
 my $samplerate = 16000;
 my $language   = "en-US";
 my $output     = "detailed";
@@ -45,10 +45,10 @@ parse_options();
 
 my %config = (
 	"encoding"         => "FLAC",
-	"sample_rate"      => $samplerate,
-	"language_code"    => $language,
-	"profanity_filter" => $pro_filter,
-	"max_alternatives" => $results,
+	"sampleRateHertz"  => $samplerate,
+	"languageCode"     => $language,
+	"profanityFilter"  => $pro_filter,
+	"maxAlternatives"  => $results,
 );
 
 my $ua = LWP::UserAgent->new(ssl_opts => {verify_hostname => 1});
@@ -87,7 +87,7 @@ foreach my $file (@ARGV) {
 		"audio"  => \%audio,
 	);
 	my $response = $ua->post(
-		"$url:syncrecognize?key=$key",
+		"$url:recognize?key=$key",
 		Content_Type => "application/json",
 		Content      => encode_json(\%json),
 	);

--- a/speech-recog-tiny.agi
+++ b/speech-recog-tiny.agi
@@ -96,7 +96,7 @@ my $beep       = "BEEP";
 my $comp_level = -1;
 my $ua_timeout = 30;
 my $tmpdir     = "/tmp";
-my $url        = "https://speech.googleapis.com/v1beta1/speech";
+my $url        = "https://speech.googleapis.com/v1/speech";
 
 # Store AGI input #
 ($AGI{arg_1}, $AGI{arg_2}, $AGI{arg_3}, $AGI{arg_4}) = @ARGV;
@@ -207,9 +207,9 @@ close($fh);
 
 my %config = (
 	"encoding"         => "FLAC",
-	"sample_rate"      => $samplerate,
-	"language_code"    => $language,
-	"profanity_filter" => $pro_filter,
+	"sampleRateHertz"  => $samplerate,
+	"languageCode"     => $language,
+	"profanityFilter"  => $pro_filter,
 );
 my %audio = ( "content" => encode_base64($audio, "") );
 
@@ -221,7 +221,7 @@ my %json = (
 # Send audio data for analysis #
 my %headers =('Content-Type' => "application/json");
 my %options = ('headers' => \%headers, 'content' => encode_json(\%json));
-my $uaresponse = $http->request('POST', "$url:syncrecognize?key=$key", \%options);
+my $uaresponse = $http->request('POST', "$url:recognize?key=$key", \%options);
 
 warn "$name The response was:\n", $uaresponse->{'content'} if ($debug);
 if (!$uaresponse->{'success'}) {

--- a/speech-recog.agi
+++ b/speech-recog.agi
@@ -96,7 +96,7 @@ my $beep       = "BEEP";
 my $comp_level = -8;
 my $ua_timeout = 30;
 my $tmpdir     = "/tmp";
-my $url        = "https://speech.googleapis.com/v1beta1/speech";
+my $url        = "https://speech.googleapis.com/v1/speech";
 
 # Store AGI input #
 ($AGI{arg_1}, $AGI{arg_2}, $AGI{arg_3}, $AGI{arg_4}) = @ARGV;
@@ -208,9 +208,9 @@ close($fh);
 
 my %config = (
 	"encoding"         => "FLAC",
-	"sample_rate"      => $samplerate,
-	"language_code"    => $language,
-	"profanity_filter" => $pro_filter,
+	"sampleRateHertz"  => $samplerate,
+	"languageCode"     => $language,
+	"profanityFilter"  => $pro_filter,
 );
 my %audio = ( "content" => encode_base64($audio, "") );
 
@@ -220,7 +220,7 @@ my %json = (
 );
 # Send audio data for analysis #
 my $uaresponse = $ua->post(
-	"$url:syncrecognize?key=$key",
+	"$url:recognize?key=$key",
 	Content_Type => "application/json",
 	Content      => encode_json(\%json),
 );


### PR DESCRIPTION
The google cloud API entered GA on April 18, see: [release notes](https://cloud.google.com/speech/release-notes)
with this release, the v1beta1 version became deprecated 

This PR updates the .agi/.pl scripts to the current V1 version